### PR TITLE
Fix whitelist_remove chat command and globalstep with absent monitoring

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -80,7 +80,7 @@ minetest.register_chatcommand("mesecons_whitelist_remove", {
     local blockpos = mesecons_debug.get_blockpos(ppos)
     local hash = minetest.hash_node_position(blockpos)
 
-    mesecons_debug.whitelist[hash] = true
+    mesecons_debug.whitelist[hash] = nil
     mesecons_debug.save_whitelist()
 
     return true, "mapblock removed from whitelist"

--- a/context.lua
+++ b/context.lua
@@ -77,7 +77,9 @@ minetest.register_globalstep(function(dtime)
 		end
   end
 
-	mapblock_count.set(mesecons_debug.context_store_size)
-	penalized_mapblock_count.set(penalized_count)
+	if has_monitoring then
+		mapblock_count.set(mesecons_debug.context_store_size)
+		penalized_mapblock_count.set(penalized_count)
+	end
 
 end)


### PR DESCRIPTION
Two minor fixes:
* The whitelist remove chat command did actually add the mapblock to the whitelist.
* Only update monitoring information if monitoring is enabled.