### PR TITLE
Add whitelist_get chat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,6 @@ All of these commands require the `mesecons_debug` privilege.
 * `/mesecons_enable` Enable the mesecons queue
 * `/mesecons_disable` Disables the mesecons queue
 * `/mesecons_stats` shows some mesecons stats for the current position
+* `/mesecons_whitelist_get` shows the list of whitelisted mapblocks
 * `/mesecons_whitelist_add` adds the current mapblock to the whitelist
 * `/mesecons_whitelist_remove` removes the current mapblock from the whitelist

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -47,6 +47,22 @@ minetest.register_chatcommand("mesecons_disable", {
   end
 })
 
+minetest.register_chatcommand("mesecons_whitelist_get", {
+  description = "shows the current mapblock whitelist",
+  privs = {mesecons_debug=true},
+  func = function(name)
+    local whitelist = "mesecons whitelist:\n"
+    local count = 0
+    for hash, _ in pairs(mesecons_debug.whitelist) do
+      whitelist = whitelist .. minetest.pos_to_string(minetest.get_position_from_hash(hash)) .. "\n"
+      count = count + 1
+    end
+    whitelist = whitelist .. string.format("%d mapblocks whitelisted", count)
+
+    return true, whitelist
+  end
+})
+
 minetest.register_chatcommand("mesecons_whitelist_add", {
   description = "adds the current mapblock to the whitelist",
   privs = {mesecons_debug=true},


### PR DESCRIPTION
This adds a new chat command that prints a list of all currently whitelisted mapblocks.

:question:  It might be helpful to also print print actual coordinates for each map block.